### PR TITLE
to support python3

### DIFF
--- a/redisgraph/client.py
+++ b/redisgraph/client.py
@@ -132,7 +132,7 @@ class Graph(object):
         response = self.redis_con.execute_command("GRAPH.QUERY", self.name, q)
         data = response[0]
         statistics = response[1]
-        result_set = [res.split(',') for res in data]
+        result_set = [res.split(b',') for res in data]
         return QueryResult(result_set, statistics)
 
     def execution_plan(self, query):


### PR DESCRIPTION

In Python 2 byte format  is treated as string 

but In python version 3 .. they are separate 
and while running redisgraph .. data elements are in bytes format in the code and 

python is thowing error with commit command  as 

`TypeError: a bytes-like object is required, not 'str' `

so i think we  need to use 

result_set = [res.*decode()*.split(',') for res in data] 

to make it compatible with python version 3 instead of 

result_set = [res.split(',') for res in data]



