### PR TITLE
Handle query stats returned as string or nested array

### DIFF
--- a/redisgraph/client.py
+++ b/redisgraph/client.py
@@ -134,7 +134,10 @@ class Graph(object):
         response = self.redis_con.execute_command("GRAPH.QUERY", self.name, q)
 
         if len(response) == 1:
-            statistics = response[0]
+            if isinstance(response[0], str):
+                statistics = response
+            else:
+                statistics = response[0]
         else:
             data = response[0]
             statistics = response[1]


### PR DESCRIPTION
This change handles returns that take the format:
```
1) "Query internal execution time: 1.473000 milliseconds"
```
I don't know if this is sufficient coverage (or even an idiomatic approach), though, so feel free to close this or request an alternate approach!

What other queries only produce statistics? SET and CREATE operations return an empty string in place of a results set, so the full output is of the form:
```
1) 1) ""
2) 1) Labels added: 1
   2) Nodes created: 1
   3) Properties set: 1
   4) "Query internal execution time: 0.122000 milliseconds"
```